### PR TITLE
Relax upper bound on version of six requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   '{{ hash_type }}': '{{ hash_value }}'
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install  --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -25,7 +25,7 @@ requirements:
     - setuptools
     - boto3 >=1.4.0,<2
     - fs >=2.0.18,<2.1
-    - six >=1.10.0,<1.11
+    - six >=1.10,<2
     - enum34  # [py2k]
 
 test:


### PR DESCRIPTION
s3fs specifies its dependency on `six` in PEP 440-style as `six~=1.10`,
which is equivalent to the Conda package match spec `six >=1.10,<2`.

See https://github.com/PyFilesystem/s3fs/pull/28

Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)